### PR TITLE
docs:Fixed markdown syntax errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The video also introduced the story of Hungarian linguist Lomb Kato, who mastere
    ```bash
    git clone https://github.com/WindChimeEcho/read-bridge.git
    cd read-bridge
-```
+   ```
 
 2. Install dependencies
    ```bash


### PR DESCRIPTION
Fixed markdown syntax errors in README.md.

Problem: Corrected a Markdown syntax error in the README.md file. The bash code block for the npm install command was incorrectly using four backticks (````) instead of the standard three (```). This has been fixed to ensure the code block renders correctly.
[This link](https://github.com/WindChimeEcho/read-bridge/blob/main/README.md#web-version)
![image](https://github.com/user-attachments/assets/b9e44069-b308-4165-9d03-d2870b5f88cb)
