### PR TITLE
docs:Fixed markdown syntax errors in README.zh-CN.md

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,12 +54,12 @@ ReadBridge的灵感来自我在一次刷视频时的偶然发现，这个视频�
    ```bash
    git clone https://github.com/WindChimeEcho/read-bridge.git
    cd read-bridge
-```
+   ```
 
 2. 安装依赖
    ```bash
    npm install
-```
+   ```
 
 3. 启动开发服务器
    ```bash


### PR DESCRIPTION
Fixed markdown syntax errors in README.zh-CN.md.

Problem: Corrected a Markdown syntax error in the README.zh-CN.md file. The bash code block for the npm install command was incorrectly using four backticks (````) instead of the standard three (```). This has been fixed to ensure the code block renders correctly.
[This link](https://github.com/WindChimeEcho/read-bridge/blob/main/README.zh-CN.md#%E7%BD%91%E9%A1%B5%E7%89%88)
![image](https://github.com/user-attachments/assets/035308fb-33ab-43ed-b4f4-9b6a05bda5c1)
